### PR TITLE
src/tools/ui: always use "%s"-style format for printf()-style functions

### DIFF
--- a/src/tools/ui.c
+++ b/src/tools/ui.c
@@ -170,25 +170,25 @@ void ui_draw_trackinfo(UI *ui)
 	mvwprintw(ui->win_ti->win, 0, 0, "Title:\n");
 	wclrtoeol(ui->win_ti->win);
 	wattroff(ui->win_ti->win, A_BOLD);
-	wprintw(ui->win_ti->win, ui->ti_title);
+	wprintw(ui->win_ti->win, "%s", ui->ti_title);
 	wclrtoeol(ui->win_ti->win);
 	wattron(ui->win_ti->win, A_BOLD);
 	wprintw(ui->win_ti->win, "\nArtist:\n");
 	wclrtoeol(ui->win_ti->win);
 	wattroff(ui->win_ti->win, A_BOLD);
-	wprintw(ui->win_ti->win, ui->ti_artist);
+	wprintw(ui->win_ti->win, "%s", ui->ti_artist);
 	wclrtoeol(ui->win_ti->win);
 	wattron(ui->win_ti->win, A_BOLD);
 	wprintw(ui->win_ti->win, "\nAlbum:\n");
 	wclrtoeol(ui->win_ti->win);
 	wattroff(ui->win_ti->win, A_BOLD);
-	wprintw(ui->win_ti->win, ui->ti_album);
+	wprintw(ui->win_ti->win, "%s", ui->ti_album);
 	wclrtoeol(ui->win_ti->win);
 	wattron(ui->win_ti->win, A_BOLD);
 	wprintw(ui->win_ti->win, "\nDate:\n");
 	wclrtoeol(ui->win_ti->win);
 	wattroff(ui->win_ti->win, A_BOLD);
-	wprintw(ui->win_ti->win, ui->ti_date);
+	wprintw(ui->win_ti->win, "%s", ui->ti_date);
 	wclrtoeol(ui->win_ti->win);
 	wclrtobot(ui->win_ti->win);
 }
@@ -326,7 +326,7 @@ static void ui_draw_footer_button(UI *ui, char *key, char *name)
 {
 	if (ui->color) wattron(ui->win_footer->win, COLOR_PAIR(2));
 	wattron(ui->win_footer->win, A_BOLD);
-	wprintw(ui->win_footer->win, key);
+	wprintw(ui->win_footer->win, "%s", key);
 	wattroff(ui->win_footer->win, A_BOLD);
 	if (ui->color) wattroff(ui->win_footer->win, COLOR_PAIR(2));
 	if (ui->color) wattron(ui->win_footer->win, COLOR_PAIR(4));


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    src/tools/ui.c: In function 'ui_draw_footer_button':
    src/tools/ui.c:329:9: error: format not a string literal and no format arguments [-Werror=format-security]
      329 |         wprintw(ui->win_footer->win, key);
          |         ^~~~~~~

Let's wrap all the missing places with "%s" format.