### PR TITLE
FRONTEND: check for glibc ver and correct gtk flag

### DIFF
--- a/src/frontends/notify.c
+++ b/src/frontends/notify.c
@@ -24,6 +24,9 @@
 #include "../debug.h"
 #include <gio/gio.h>
 
+#if !GLIB_CHECK_VERSION(2, 74, 0)
+#define G_APPLICATION_DEFAULT_FLAGS G_APPLICATION_FLAGS_NONE
+#endif
 static int notify_enabled = 0;
 
 static const char *get_name(void)


### PR DESCRIPTION
Otherwise it will fail build on glibc prev. to 2.74, which may be trouebling while cross-compiling for older architectures:
```make
src/frontends/notify.c:64:77: error: ‘G_APPLICATION_DEFAULT_FLAGS’ undeclared (first use in this function); did you mean ‘G_APPLICATION_GET_CLASS’?
   64 |                         application = g_application_new("gmu.music.player", G_APPLICATION_DEFAULT_FLAGS);
      |                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                             G_APPLICATION_GET_CLASS
src/frontends/notify.c:64:77: note: each undeclared identifier is reported only once for each function it appears in
make: *** [Makefile:237: frontends/notify.so] Error 1
```

for reference: https://docs.gtk.org/gio/flags.ApplicationFlags.html#flags_none